### PR TITLE
Updates for the raidboss map

### DIFF
--- a/EMSconfigs/(4) ems im graben der verdammnis.lua
+++ b/EMSconfigs/(4) ems im graben der verdammnis.lua
@@ -19,7 +19,7 @@ EMS_CustomMapConfig =
 	-- * Configuration File Version
 	-- * A version check will make sure every player has the same version of the configuration file
 	-- ********************************************************************************************
-	Version = 1.6,
+	Version = 1.7,
 	ActivateDebug = false,
  
 	-- ********************************************************************************************

--- a/EMSconfigs/(4) ems im graben der verdammnis.lua
+++ b/EMSconfigs/(4) ems im graben der verdammnis.lua
@@ -326,7 +326,7 @@ function WT21.ReviveKerberos()
 end
 function WT21.IncreaseKerbeStrength()
 	-- increase max health
-	Raidboss.MaxHealth = Raidboss.MaxHealth * 1.5
+	Raidboss.MaxHealth = math.floor(Raidboss.MaxHealth * 1.5)
 	SW.SetSettlerMaxHealth( Entities.CU_BlackKnight, Raidboss.MaxHealth)
 
 	local schemes = Raidboss.AttackSchemes
@@ -350,7 +350,7 @@ function WT21.MakeVCsImmune()
 		{pos = {X = 23300, Y = 28300}, n =  {X = 1, Y = 1}},
 		{pos = {X = 23300, Y = 42200}, n =  {X = 1, Y = -1}},
 		{pos = {X = 47600, Y = 42200}, n =  {X = -1, Y = -1}},
-		{pos = {X = 47600, Y = 28300}, n =  {X = -1, Y = 1}}
+		{pos = {X = 47600, Y = 28400}, n =  {X = -1, Y = 1}}
 	}
 	Trigger.RequestTrigger( Events.LOGIC_EVENT_ENTITY_HURT_ENTITY, "", "WT21_ProtectVCs", 1)
 end
@@ -377,7 +377,7 @@ function WT21_ProtectVCs()
 		if math.abs(v.pos.X - pos.X) + math.abs(v.pos.Y - pos.Y) < 100 then
 			--LuaDebugger.Log("Found matching VC")
 			-- left to check: is attacker in center?
-			local newPos = {X = pos.X + 1000 * v.n.X, Y = pos.Y + 1000 * v.n.Y}
+			local newPos = {X = pos.X + 500 * v.n.X, Y = pos.Y + 500 * v.n.Y}
 			local attackerPos = GetPosition(attacker)
 			-- now do some linear algebra / functional analysis
 			local dotProd = (attackerPos.X - newPos.X)*v.n.X + (attackerPos.Y - newPos.Y)*v.n.Y
@@ -1017,7 +1017,7 @@ function Raidboss.ActivateKerbeInfoWidget()
 	StartSimpleJob("Raidboss_UpdateInfoWidget")
 	GUIUpdate_UpdateDebugInfo = function()
 		-- the state kerbe is currently in
-		local currState = WT21.KerbeDamageFactorStates[WT21.CurrentState].label
+		local currState = WT21.KerbeDamageFactorStates[WT21.DamageFactorsCurrentState].label
 		-- some information about the hp
 		local hpString = "Hitpoints: "..Logic.GetEntityHealth(Raidboss.eId).."/"..Raidboss.MaxHealth
 		-- information about the last attack, maybe later


### PR DESCRIPTION
The winter tournament showed a few flaws of the map. This update tries to fix them.

> Minor changes
- Villages centers are immune against ranged attacks from the center.
- Added some information about kerberos on the top left, only shown if and only if kerberos is visible for the player and if the mouse cursor is nearby.

> Changes to the damage factors
- Bug fix: Soldier now deal more than 1 to 3 damage points per hit.
- Boni now stack differently: Actual damage = (base damage + statue bonus) * church factor * weapon type factor
- Weapon type factor is 2.5 for all melees, and either 0, 1 or 2 for ranged infantery(and cavalry), depending on the **phase**.
- Kerberos now has different **phases** where he is either normal, immune to bullets and weak to arrows or vice versa. Phases change randomly but not while kerberos is lying on the ground. The probability that kerberos switches his phase in the next minute is _always_ 50%.
- Church factor was buffed: 2 churches equal **quad damage** now, bonus for 1 church unchanged.
- Statues were nerfed and yield diminishing returns. Maximum bonus is **+40 damage** now. Important break points:
- - For the first 17 statues each statue yields +1 damage.
- - +25 damage is achieved with 28 statues.
- - +30 damage is achieved with 37 statues.
- - +35 damage is achieved with 51 statues.
- - +40 damage is achieved with 88 statues.
- - The actual formula is shown [here](https://www.wolframalpha.com/input?i=plot+f%28x%29+%3D+ceil%2880%2F%281%2Bexp%28-x%2F20%29%29+-+40%29+from+x+%3D+0+to+90).

> Changes to kerberos behavior
- Kerberos now revives with full health.
- Kerberos now grows stronger with each revive. Attacks get faster and more devastating and his hp pool increases exponentially.
- Attack selection should be more predictable now. Attacks are not selected totally random anymore, some attacks define custom probabilities for the follow up attacks.